### PR TITLE
forwardRef en react v19

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,8 @@ function App() {
   );
 
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
-    console.log(inputRef, "inputRef");
-    console.log(inputContainerRef, "inputContainerRef");
+    console.log(inputRef.current, "inputRef");
+    console.log(inputContainerRef.current, "inputContainerRef");
 
     if (acceptedFiles.length) {
       const file = acceptedFiles[0];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState, useActionState } from "react";
+import { useCallback, useState, useActionState, useRef } from "react";
 import { useDropzone } from "react-dropzone";
 
 import mockUploadImage, { initialStateType } from "./utils/mockUploadImage";
 import "./App.css";
 import SubmitButton from "./components/SubmitButton";
-import CommentsSection from "./components/CommentsSection";
+import CustomInput from "./components/CustomInput";
+// import CommentsSection from "./components/CommentsSection";
 
 const initialState: initialStateType = {
   success: false,
@@ -13,6 +14,8 @@ const initialState: initialStateType = {
 };
 
 function App() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputContainerRef = useRef<HTMLDivElement>(null);
   const [file, setFile] = useState<File>();
   const [{ error, success }, formAction] = useActionState(
     mockUploadImage,
@@ -20,6 +23,9 @@ function App() {
   );
 
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    console.log(inputRef, "inputRef");
+    console.log(inputContainerRef, "inputContainerRef");
+
     if (acceptedFiles.length) {
       const file = acceptedFiles[0];
 
@@ -44,7 +50,7 @@ function App() {
     );
   };
 
-  /*return (
+  return (
     <form className="container" action={formAction}>
       <h2 className="title"> Administrador de archivos</h2>
       <div className="input-area" {...getRootProps()}>
@@ -53,10 +59,11 @@ function App() {
         {!success && !!error && <p className="error">{error}</p>}
       </div>
       {!!file && <SubmitButton />}
+      <CustomInput label="Prueba" ref={inputContainerRef} inputRef={inputRef} />
     </form>
-  );*/
+  );
 
-  return <CommentsSection />;
+  // return <CommentsSection />;
 }
 
 export default App;

--- a/src/components/CustomInput.tsx
+++ b/src/components/CustomInput.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, InputHTMLAttributes, RefObject } from "react";
+
+type CustomInputProps = {
+  label?: string;
+  errorMsg?: string;
+  inputRef?: RefObject<HTMLInputElement | null>;
+} & InputHTMLAttributes<HTMLInputElement>;
+
+const CustomInput = forwardRef<HTMLDivElement, CustomInputProps>(
+  ({ label, errorMsg, inputRef, ...inputProps }, ref) => {
+    console.log(ref);
+
+    return (
+      <div ref={ref}>
+        <label>
+          {label}
+          <input {...inputProps} ref={inputRef} />
+        </label>
+        {!!errorMsg && <span>{errorMsg}</span>}
+      </div>
+    );
+  }
+);
+
+export default CustomInput;

--- a/src/components/CustomInput.tsx
+++ b/src/components/CustomInput.tsx
@@ -1,25 +1,26 @@
-import { forwardRef, InputHTMLAttributes, RefObject } from "react";
+import { FC, InputHTMLAttributes, RefObject } from "react";
 
 type CustomInputProps = {
   label?: string;
   errorMsg?: string;
   inputRef?: RefObject<HTMLInputElement | null>;
+  ref?: RefObject<HTMLDivElement | null>;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-const CustomInput = forwardRef<HTMLDivElement, CustomInputProps>(
-  ({ label, errorMsg, inputRef, ...inputProps }, ref) => {
-    console.log(ref);
-
-    return (
-      <div ref={ref}>
-        <label>
-          {label}
-          <input {...inputProps} ref={inputRef} />
-        </label>
-        {!!errorMsg && <span>{errorMsg}</span>}
-      </div>
-    );
-  }
+const CustomInput: FC<CustomInputProps> = ({
+  label,
+  errorMsg,
+  inputRef,
+  ref,
+  ...inputProps
+}) => (
+  <div ref={ref}>
+    <label>
+      {label}
+      <input {...inputProps} ref={inputRef} />
+    </label>
+    {!!errorMsg && <span>{errorMsg}</span>}
+  </div>
 );
 
 export default CustomInput;


### PR DESCRIPTION

En este PR, se implemento `forwareRef` como en la version de React v18.

Se removio `forwareRef` en react 19. Funciona normalmente en la version 19 pero ya no es necesario.

Nota: `forwareRef` en react v19 ya no es necesario.
![Screen Shot 2025-01-06 at 1 53 45 p m](https://github.com/user-attachments/assets/aead624c-9456-41a3-a190-9419b7939ed9)

